### PR TITLE
fix: duplicated CannyEdgeOperation

### DIFF
--- a/includes/CannyEdgeOperation.h
+++ b/includes/CannyEdgeOperation.h
@@ -10,11 +10,6 @@ public:
     int kernelSize;
     explicit CannyEdgeOperation(int low, int high, int kSize);
     void apply(Mat& image) override;
-    explicit CannyEdgeOperation(int low, int high, int kSize);
-private:
-    int lowThreshold;
-    int highThreshold;
-    int kernelSize;
 };
 
 


### PR DESCRIPTION
This pull request includes a small change to the `CannyEdgeOperation` class in `includes/CannyEdgeOperation.h`. The change removes redundant code by eliminating a duplicate constructor declaration and unused private member variables (`lowThreshold`, `highThreshold`, and `kernelSize`).